### PR TITLE
Document installing the namespaced package via npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ var point = new Point(0, 1);
 Requires [nodejs](http://nodejs.org/).
 
 ```sh
-$ npm install point-geometry
+$ npm install @mapbox/point-geometry
 ```
 
 ## Tests


### PR DESCRIPTION
The README.md still references the package name without the mapbox namespace.